### PR TITLE
Add Slopper PR analysis

### DIFF
--- a/.github/workflows/slopper.yml
+++ b/.github/workflows/slopper.yml
@@ -1,0 +1,19 @@
+name: Slopper
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: malvads/slopper@main
+        with:
+          ai-provider: 'groq'
+          groq-api-key: ${{ secrets.GROQ_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.slopper
+++ b/.slopper
@@ -1,0 +1,30 @@
+vouched:
+  - malvads
+  - dependabot[bot]
+
+actions:
+  auto_close:
+    enabled: false
+    threshold: 9
+  auto_approve:
+    enabled: false
+    threshold: 2
+  auto_request_review:
+    enabled: false
+    threshold: 6
+    reviewers: []
+
+thresholds:
+  low: 2
+  medium: 5
+  high: 8
+
+ignore_paths:
+  - "*.md"
+  - "LICENSE"
+
+rules:
+  require_description: true
+  require_linked_issue: false
+  max_files_changed: 0
+  block_first_time_contributors: false


### PR DESCRIPTION
## Summary

Adds the Slopper GitHub Action to analyze pull requests for AI slop and low-quality contributions. Uses Groq as the AI provider.

The workflow triggers on PR open, synchronize, and reopened events, as well as issue comments (for `/slopper vouch` commands).

Requires a `GROQ_API_KEY` secret to be configured in the repository settings.